### PR TITLE
Update WTDecoder.cpp

### DIFF
--- a/Funkthermometer/WTDecoder.cpp
+++ b/Funkthermometer/WTDecoder.cpp
@@ -182,9 +182,11 @@ bool WTDecoder::GetRecord(struct rec &record)
 
 char *WTDecoder::Record2String(struct rec &record)
 {
-  sprintf(mBuffer, "Sensor %d : %0.1f°C %d%% (%02x%s%s)",
+   char str_temp[10];
+   dtostrf((float) record.temperature / 10.0, 3, 1, str_temp);
+   sprintf(mBuffer, "Sensor %d : %s°C %d%% (%02x%s%s)",
     record.channel + 1,
-    (float) record.temperature / 10.0,
+    str_temp,
     record.humidity,
     record.txid,
     record.battery ? ", LOW BAT" : "",


### PR DESCRIPTION
Due to some performance reasons %f is not included in the Arduino's implementation of sprintf(). A better option would be to use dtostrf(). See also 
https://stackoverflow.com/questions/27651012/arduino-sprintf-float-not-formatting